### PR TITLE
Tracer setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# hopper
-A packet tracer in Go. Similer to Traceroute.
+# Tracer
+A packet tracer in Go similer to Traceroute.
+
+Makes UDP call to target host increasing the TTL(hops) of IP packet and recording the ICMP response for each hop until it finally reaches the destination or max TTL is reached.

--- a/README.md
+++ b/README.md
@@ -2,3 +2,14 @@
 A packet tracer in Go similer to Traceroute.
 
 Makes UDP call to target host increasing the TTL(hops) of IP packet and recording the ICMP response for each hop until it finally reaches the destination or max TTL is reached.
+
+
+### Test
+```bash
+go run cmd/main.go -help
+
+# Yes, previleged access is needed while creatig raw sockets for ICMP
+sudo go run cmd/main.go example.com
+
+sudo go run cmd/main.go -hops 5 -timeout 2 example.com
+```

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/nirdosh17/tracer"
+)
+
+// go run cmd/main.go -hops 20 -timeout 120 google.com
+func main() {
+	hops := flag.Int("hops", 64, "max hops(TTL) for the packet, default: 64")
+	timeout := flag.Int("timeout", 100, "timeout(ms) for ICMP response, default: 100")
+	flag.Parse()
+
+	host := flag.Arg(0)
+	if len(host) == 0 {
+		fmt.Println("no host provided!")
+		os.Exit(1)
+	}
+
+	// consume live hops from channel
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	c := make(chan tracer.Hop)
+	go func() {
+		for {
+			hop, ok := <-c
+			if !ok {
+				// channel closed, so exiting
+				wg.Done()
+				return
+			}
+			fmt.Println("received hop", hop)
+		}
+	}()
+
+	config := tracer.NewConfig().WithHops(*hops).WithTimeout(*timeout)
+	t := tracer.NewTracer(config)
+	err := t.Run(host, c)
+	if err != nil {
+		fmt.Println("Error from Trace runner: ", err)
+	}
+	wg.Wait()
+}

--- a/config.go
+++ b/config.go
@@ -1,19 +1,19 @@
 package tracer
 
 const (
-	DEFAULT_HOPS       = 64
-	DEFAULT_TIMEOUT_MS = 100
+	DEFAULT_HOPS            = 64
+	DEFAULT_TIMEOUT_SECONDS = 5
 )
 
 type TracerConfig struct {
-	MaxHops   int
-	TimeoutMs int
+	MaxHops        int
+	TimeoutSeconds int
 }
 
 func NewConfig() *TracerConfig {
 	return &TracerConfig{
-		MaxHops:   DEFAULT_HOPS,
-		TimeoutMs: DEFAULT_TIMEOUT_MS,
+		MaxHops:        DEFAULT_HOPS,
+		TimeoutSeconds: DEFAULT_TIMEOUT_SECONDS,
 	}
 }
 
@@ -25,10 +25,10 @@ func (t *TracerConfig) Hops() int {
 }
 
 func (t *TracerConfig) Timeout() int {
-	if t.TimeoutMs == 0 {
-		t.TimeoutMs = DEFAULT_TIMEOUT_MS
+	if t.TimeoutSeconds == 0 {
+		t.TimeoutSeconds = DEFAULT_TIMEOUT_SECONDS
 	}
-	return t.TimeoutMs
+	return t.TimeoutSeconds
 }
 
 func (t *TracerConfig) WithHops(h int) *TracerConfig {
@@ -37,6 +37,6 @@ func (t *TracerConfig) WithHops(h int) *TracerConfig {
 }
 
 func (t *TracerConfig) WithTimeout(to int) *TracerConfig {
-	t.TimeoutMs = to
+	t.TimeoutSeconds = to
 	return t
 }

--- a/config.go
+++ b/config.go
@@ -1,0 +1,42 @@
+package tracer
+
+const (
+	DEFAULT_HOPS       = 64
+	DEFAULT_TIMEOUT_MS = 100
+)
+
+type TracerConfig struct {
+	MaxHops   int
+	TimeoutMs int
+}
+
+func NewConfig() *TracerConfig {
+	return &TracerConfig{
+		MaxHops:   DEFAULT_HOPS,
+		TimeoutMs: DEFAULT_TIMEOUT_MS,
+	}
+}
+
+func (t *TracerConfig) Hops() int {
+	if t.MaxHops == 0 {
+		t.MaxHops = DEFAULT_HOPS
+	}
+	return t.MaxHops
+}
+
+func (t *TracerConfig) Timeout() int {
+	if t.TimeoutMs == 0 {
+		t.TimeoutMs = DEFAULT_TIMEOUT_MS
+	}
+	return t.TimeoutMs
+}
+
+func (t *TracerConfig) WithHops(h int) *TracerConfig {
+	t.MaxHops = h
+	return t
+}
+
+func (t *TracerConfig) WithTimeout(to int) *TracerConfig {
+	t.TimeoutMs = to
+	return t
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/nirdosh17/tracer
 
 go 1.22.0
+
+require (
+	golang.org/x/net v0.26.0 // indirect
+	golang.org/x/sys v0.21.0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/nirdosh17/tracer
+
+go 1.22.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
+golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/locate.go
+++ b/locate.go
@@ -1,0 +1,41 @@
+package tracer
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// geoResponse represents the response from the geolocation API
+type geoResponse struct {
+	IP      string `json:"query"`
+	Country string `json:"country"`
+	Region  string `json:"regionName"`
+	City    string `json:"city"`
+	Org     string `json:"org"`
+}
+
+func locateIP(ip string) geoResponse {
+	defaultResp := geoResponse{}
+	url := fmt.Sprintf("http://ip-api.com/json/%s", ip)
+	resp, err := http.Get(url)
+	if err != nil {
+		fmt.Println("[locateIP] failed to fetch location info for IP", ip, err)
+		return defaultResp
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println("[locateIP] failed to read resp body:", err)
+		return defaultResp
+	}
+
+	var geo geoResponse
+	err = json.Unmarshal(body, &geo)
+	if err != nil {
+		fmt.Println("[locateIP] error unmarshaling response:", err)
+	}
+	return geo
+}

--- a/trace.go
+++ b/trace.go
@@ -2,7 +2,17 @@ package tracer
 
 import (
 	"fmt"
+	"log"
+	"net"
+	"syscall"
 	"time"
+
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
+)
+
+const (
+	UDPStartPort = 33434
 )
 
 type Tracer struct {
@@ -10,11 +20,8 @@ type Tracer struct {
 }
 
 type Hop struct {
-	SourceIP   string
-	SourcePort string
-	// ip from which icmp packet was received
-	DestIP   string
-	DestPort string
+	Addr     string
+	Location string
 	// current ttl(hops) of the packet
 	TTL int
 	// total time taken for this hop
@@ -25,15 +32,182 @@ func NewTracer(c *TracerConfig) *Tracer {
 	return &Tracer{Config: c}
 }
 
+type NetworkTrace struct {
+	RoundTripTime time.Duration
+	NetworkHops   []Hop
+}
+
 // Run sends packets to the specified host in loop recording each network hop until it reaches the destination or max hops is reached.
 // It also collects traces in the given channel.
 //
-// e.g. domain = google.com
-func (t Tracer) Run(domain string, traces chan Hop) error {
-	fmt.Printf("configs: %+v\n", *t.Config)
+// e.g. host = example.com
+func (t Tracer) Run(host string, traces chan Hop) (NetworkTrace, error) {
+	nTrace := NetworkTrace{}
+	nHops := []Hop{}
 
-	traces <- Hop{DestIP: "254.178.123.100"}
+	// resolve host(e.g. example.com) into an IP
+	destIP, err := net.ResolveIPAddr("ip", host)
+	if err != nil {
+		return nTrace, fmt.Errorf("unable to resolve host %s", host)
+	}
+
+	roundTripStart := time.Now()
+	for ttl := 1; ttl <= t.Config.MaxHops; ttl++ {
+		// using different UDP port each time
+		port := UDPStartPort + ttl
+		addr := fmt.Sprintf("%s:%d", destIP, port)
+
+		now := time.Now()
+		err = t.sendUDPPacket(addr, ttl)
+		if err != nil {
+			fmt.Printf("Error sending UDP packet: %s\n", err)
+			continue
+		}
+
+		recv, err := t.listenICMPMessages()
+		if err != nil {
+			fmt.Printf("Error listening for ICMP replies: %s\n", err)
+			continue
+		}
+		elapsedTime := time.Since(now)
+
+		// TODO: find out why this is nil
+		if recv.packetAddr == nil {
+			continue
+		}
+
+		packetAddr := recv.packetAddr.String()
+		if recv.destIP == destIP.IP.String() {
+			loc := locateIP(packetAddr)
+			hop := Hop{
+				TTL:         ttl,
+				Addr:        packetAddr,
+				Location:    fmt.Sprintf("%v (%v)", loc.Country, loc.Org),
+				ElapsedTime: elapsedTime,
+			}
+
+			// push to channel for live updates
+			traces <- hop
+
+			nHops = append(nHops, hop)
+		}
+
+		if packetAddr == recv.destIP {
+			break
+		}
+	}
+	nTrace.RoundTripTime = time.Since(roundTripStart)
+	nTrace.NetworkHops = nHops
 
 	close(traces)
-	return nil
+
+	return nTrace, nil
+}
+
+// sendUDPPacket sends UDP datagrams with a specified TTL.
+// After setting up an ICMP listener, we use this method to send UDP datagrams wrapped in IP packets.
+func (t Tracer) sendUDPPacket(addr string, ttl int) error {
+	// Resolve the UDP address
+	udpAddr, err := net.ResolveUDPAddr("udp", addr)
+	if err != nil {
+		return err
+	}
+
+	// Create a UDP connection
+	conn, err := net.DialUDP("udp", nil, udpAddr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	// Set the TTL
+	rawConn, err := conn.SyscallConn()
+	if err != nil {
+		return err
+	}
+
+	err = rawConn.Control(func(fd uintptr) {
+		if udpAddr.IP.To4() != nil {
+			err = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, syscall.IP_TTL, ttl)
+		} else {
+			err = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IPV6, syscall.IPV6_UNICAST_HOPS, ttl)
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	// Sending a UDP packet with dummy payload. Why?
+	// - actual content in payload sent in the UDP packet does not affect traceroute operation
+	// - primary purpose of payload is to generate ICMP responses at each hop
+	_, err = conn.Write([]byte("HI"))
+	return err
+}
+
+// listenICMPMessages listens all ICMP messages incoming in the machine.
+// Filter outs unknown messages using caller IP.
+func (t Tracer) listenICMPMessages() (icmpResp, error) {
+	defaultResp := icmpResp{}
+	c, err := net.ListenPacket("ip4:icmp", "0.0.0.0")
+	if err != nil {
+		return icmpResp{}, fmt.Errorf("failed to listen icmp %v", err)
+	}
+	defer c.Close()
+
+	c.SetReadDeadline(time.Now().Add(time.Duration(t.Config.TimeoutSeconds * int(time.Second))))
+	buffer := make([]byte, 1500)
+
+	for {
+		receivedBytesLen, receivedFrom, err := c.ReadFrom(buffer)
+		if err != nil && receivedBytesLen == 0 {
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				// after finishing reading from connection, it will timeout in the next loop when there is nothing to read
+				// so not need to log error message
+				// fmt.Println("Request timed out.", err)
+				return defaultResp, nil
+			}
+			return defaultResp, err
+		}
+
+		icmpMsg, err := t.parseICMP(buffer, receivedBytesLen)
+		if err != nil {
+			return defaultResp, nil
+		}
+
+		switch icmpMsg.icmpType {
+		case ipv4.ICMPTypeTimeExceeded, ipv4.ICMPTypeDestinationUnreachable:
+			icmpMsg.packetAddr = receivedFrom
+			return icmpMsg, nil
+		default:
+			log.Printf("got %+v; want echo reply", icmpMsg.icmpType)
+			return defaultResp, nil
+		}
+	}
+
+}
+
+type icmpResp struct {
+	code int
+	// the last host where test UDP datagram reached with given TTL or the ICMP sender
+	packetAddr  net.Addr
+	icmpType    icmp.Type
+	requesterIP string
+	// we are only interested in ICMP packets which were send to this IP
+	// but they might not have reached to this destination due to small TTL
+	destIP string
+}
+
+func (t Tracer) parseICMP(buffer []byte, length int) (icmpResp, error) {
+	var msg icmpResp
+	msg.destIP = net.IP(buffer[24:28]).String()
+	msg.requesterIP = net.IP(buffer[20:24]).String()
+
+	im, err := icmp.ParseMessage(1, buffer[:length])
+	if err != nil {
+		return msg, fmt.Errorf("failed to parse icmp msg %v", err)
+	}
+	msg.icmpType = im.Type
+	msg.code = im.Code
+
+	return msg, nil
 }

--- a/trace.go
+++ b/trace.go
@@ -1,0 +1,39 @@
+package tracer
+
+import (
+	"fmt"
+	"time"
+)
+
+type Tracer struct {
+	Config *TracerConfig
+}
+
+type Hop struct {
+	SourceIP   string
+	SourcePort string
+	// ip from which icmp packet was received
+	DestIP   string
+	DestPort string
+	// current ttl(hops) of the packet
+	TTL int
+	// total time taken for this hop
+	ElapsedTime time.Duration
+}
+
+func NewTracer(c *TracerConfig) *Tracer {
+	return &Tracer{Config: c}
+}
+
+// Run sends packets to the specified host in loop recording each network hop until it reaches the destination or max hops is reached.
+// It also collects traces in the given channel.
+//
+// e.g. domain = google.com
+func (t Tracer) Run(domain string, traces chan Hop) error {
+	fmt.Printf("configs: %+v\n", *t.Config)
+
+	traces <- Hop{DestIP: "254.178.123.100"}
+
+	close(traces)
+	return nil
+}


### PR DESCRIPTION
**Implemented UDP - ICMP based packet tracer:**
- First we setup an ICMP listener
- Then, first we continuously make UDP request before it reaches the specified max hops (aka. TTL in a IP packet)
- If Max hop = 1, it the packet will expire in the first hop. i.e. our router or any host will send ICMP error message packet saying that TTL has expired.
-  We track all ICMP messages,  filtering them by destination IP so that other incoming ICMP packets in the OS do not interfere with ours.
- If max hop is reached, we stop sending packets.