### PR TITLE
Add retry option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Tracer
 A packet tracer in Go similar to Traceroute.
 
-Makes UDP call to target host increasing the TTL(hops) of IP packet and recording the ICMP response for each hop until it finally reaches the destination or max TTL is reached.
+Makes UDP call to target host increasing the TTL(hops) of IP packet and recording the ICMP response for each hop(router address) until it finally reaches the destination or max TTL is reached.
 
 
 ### Test

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Tracer
-A packet tracer in Go similar to Traceroute.
+Network diagnostic tool in Go inspired by Traceroute.
 
 Makes UDP call to target host increasing the TTL(hops) of IP packet and recording the ICMP response for each hop(router address) until it finally reaches the destination or max TTL is reached.
-
 
 ### Test
 ```bash
@@ -15,20 +14,12 @@ sudo go run cmd/main.go -hops 5 -timeout 2 example.com
 ```
 **Sample output:**
 ```bash
-tracing example.com (93.184.215.14), 64 hops max
-1.   10.80.70.255     ()    1.154591ms
-2.   138.197.249.110    Canada (DigitalOcean, LLC)    1.62412ms
-3.   143.244.192.42    Canada (DigitalOcean, LLC)    867.255µs
-4.   143.244.224.142    Canada (DigitalOcean, LLC)    923.144µs
-5.   143.244.224.147    Canada (DigitalOcean, LLC)    1.125888ms
-6.   213.248.88.244    United Kingdom (Arelion)    1.369646ms
-7.   62.115.127.6    United Kingdom (Telia Company AB)    2.111305ms
-8.   62.115.113.20    United States (Telia Company AB)    76.752301ms
-9.   62.115.112.242    United States (Telia Company AB)    88.230903ms
-10.   62.115.147.199    United States (Arelion Sweden AB)    78.454842ms
-11.   152.195.68.135    United States (Verizon Business)    76.296614ms
-12.   62.115.141.245    United States (Telia Company AB)    85.042073ms
-13.   152.195.68.133    United States (Verizon Business)    122.720549ms
-14.   93.184.215.14    United Kingdom ()    78.305133ms
-Total Round Trip Time: 3.722480376s
+tracing example.com (93.184.215.14), 64 hops max, max retries: 2
+1.   192.168.101.1    private range    12.023833ms
+2.   62.115.42.118    Arelion Sweden AB (France)    178.632ms
+3.   62.115.122.159    TELIANET (United States)    281.884917ms
+4.   62.115.123.125    TELIANET (United States)    305.271958ms
+5.   62.115.175.71    Arelion Sweden AB (United States)    277.827958ms
+6.   152.195.64.153    Edgecast Inc. (United States)    276.270542ms
+7.   93.184.215.14    Edgecast Inc. (United Kingdom)    305.162792ms
 ```

--- a/config.go
+++ b/config.go
@@ -3,17 +3,20 @@ package tracer
 const (
 	DEFAULT_HOPS            = 64
 	DEFAULT_TIMEOUT_SECONDS = 5
+	DEFAULT_MAX_RETRIES     = 2
 )
 
 type TracerConfig struct {
 	MaxHops        int
 	TimeoutSeconds int
+	MaxRetries     int
 }
 
 func NewConfig() *TracerConfig {
 	return &TracerConfig{
 		MaxHops:        DEFAULT_HOPS,
 		TimeoutSeconds: DEFAULT_TIMEOUT_SECONDS,
+		MaxRetries:     DEFAULT_MAX_RETRIES,
 	}
 }
 
@@ -31,6 +34,13 @@ func (t *TracerConfig) Timeout() int {
 	return t.TimeoutSeconds
 }
 
+func (t *TracerConfig) Retries() int {
+	if t.MaxRetries == 0 {
+		t.MaxRetries = DEFAULT_MAX_RETRIES
+	}
+	return t.MaxRetries
+}
+
 func (t *TracerConfig) WithHops(h int) *TracerConfig {
 	t.MaxHops = h
 	return t
@@ -38,5 +48,10 @@ func (t *TracerConfig) WithHops(h int) *TracerConfig {
 
 func (t *TracerConfig) WithTimeout(to int) *TracerConfig {
 	t.TimeoutSeconds = to
+	return t
+}
+
+func (t *TracerConfig) WithMaxRetries(n int) *TracerConfig {
+	t.MaxRetries = n
 	return t
 }

--- a/locate.go
+++ b/locate.go
@@ -7,35 +7,39 @@ import (
 	"net/http"
 )
 
-// geoResponse represents the response from the geolocation API
+// check available fields here: https://ip-api.com/#8.8.8.8
 type geoResponse struct {
-	IP      string `json:"query"`
-	Country string `json:"country"`
-	Region  string `json:"regionName"`
-	City    string `json:"city"`
-	Org     string `json:"org"`
+	Country      string `json:"country"`
+	Isp          string `json:"isp"`
+	QueryStatus  string `json:"status"`
+	QueryMessage string `json:"message"`
 }
 
-func locateIP(ip string) geoResponse {
-	defaultResp := geoResponse{}
+func locateIP(ip string) string {
 	url := fmt.Sprintf("http://ip-api.com/json/%s", ip)
 	resp, err := http.Get(url)
 	if err != nil {
 		fmt.Println("[locateIP] failed to fetch location info for IP", ip, err)
-		return defaultResp
+		return "N/A"
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		fmt.Println("[locateIP] failed to read resp body:", err)
-		return defaultResp
+		return "N/A"
 	}
 
 	var geo geoResponse
 	err = json.Unmarshal(body, &geo)
 	if err != nil {
 		fmt.Println("[locateIP] error unmarshaling response:", err)
+		return "N/A"
 	}
-	return geo
+
+	if geo.QueryStatus == "fail" {
+		return geo.QueryMessage
+	}
+
+	return fmt.Sprintf("%v (%v)", geo.Isp, geo.Country)
 }


### PR DESCRIPTION
**Changes**
- Add option to retry when ICMP read timeout occurs
- Label private IPs as 'private range' as shown below:
```bash
tracing example.com (93.184.215.14), 64 hops max, max retries: 2
1.   192.168.101.1    private range    2.242833ms
```