### PR TITLE
Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Makes UDP call to target host increasing the TTL(hops) of IP packet and recordin
 
   **Get public IP:**
 
-  ![Get IP](https://github.com/nirdosh17/tracer/assets/5920689/2fa173d2-5b8c-4fb3-841b-d0c2cadaf08a)
+  ![Get IP](https://github.com/nirdosh17/tracer/assets/5920689/863aef4e-996f-4c37-9386-2203f7576930)
 
   **Trace route:**
 

--- a/cmd/gotrace/main.go
+++ b/cmd/gotrace/main.go
@@ -107,7 +107,7 @@ func traceRoute(host string, hops, retries, timeout *int) {
 				wg.Done()
 				return
 			}
-			printHop(hop)
+			hop.Print()
 		}
 	}()
 
@@ -120,12 +120,4 @@ func traceRoute(host string, hops, retries, timeout *int) {
 		fmt.Printf("failed to trace route for %v: %v\n", host, err)
 		os.Exit(1)
 	}
-}
-
-func printHop(hop tracer.Hop) {
-	et := hop.ElapsedTime.String()
-	if hop.ElapsedTime == 0 {
-		et = "*"
-	}
-	fmt.Printf("%v.   %v    %v    %v\n", hop.TTL, hop.Addr, hop.Location, et)
 }

--- a/cmd/gotrace/main.go
+++ b/cmd/gotrace/main.go
@@ -67,13 +67,15 @@ func main() {
 		traceRoute(host, hops, retries, timeout)
 
 	case "myip":
-		pubIP, err := tracer.PublicIP()
+		pubIPv4, pubIPv6, loc, err := tracer.PublicIP()
 		if err != nil {
 			fmt.Println("failed to fetch your public ip:", err)
 			os.Exit(1)
 		}
 		fmt.Println("Your Public IP:")
-		fmt.Println(pubIP)
+		fmt.Println("IPv4:", pubIPv4)
+		fmt.Println("IPv6:", pubIPv6)
+		fmt.Println(loc)
 
 	case "-h", "-help":
 		flag.Usage()

--- a/locate.go
+++ b/locate.go
@@ -76,6 +76,7 @@ func PublicIP() (string, error) {
 			stunErr = res.Error
 			return
 		}
+		// TODO: this sometimes returns ipv6 address, either print just ipv4 or print both
 		pubIP = xorAddr.IP
 
 	}); err != nil {

--- a/trace.go
+++ b/trace.go
@@ -18,6 +18,10 @@ type Tracer struct {
 	Config *TracerConfig
 }
 
+func NewTracer(c *TracerConfig) *Tracer {
+	return &Tracer{Config: c}
+}
+
 type Hop struct {
 	// this should be host or IP address
 	Addr     string
@@ -28,8 +32,12 @@ type Hop struct {
 	ElapsedTime time.Duration
 }
 
-func NewTracer(c *TracerConfig) *Tracer {
-	return &Tracer{Config: c}
+func (h Hop) Print() {
+	et := h.ElapsedTime.Round(time.Microsecond).String()
+	if h.ElapsedTime == 0 {
+		et = "*"
+	}
+	fmt.Printf("%v.   %v    %v    %v\n", h.TTL, h.Addr, h.Location, et)
 }
 
 type NetworkTrace struct {
@@ -205,7 +213,7 @@ type icmpResp struct {
 	packetAddr  net.Addr
 	icmpType    icmp.Type
 	requesterIP string
-	// we are only interested in ICMP packets which were send to this IP
+	// we are only interested in ICMP packets which were sent to this IP
 	// but they might not have reached to this destination due to small TTL
 	destIP string
 }


### PR DESCRIPTION
- Roundoff elapsed time to MicroSecond (3 digits)
- Instead of relying on STUN server to send IPv4 or V6 randomly, specify protocol+version while making STUN requests. -
- Display both API versions.